### PR TITLE
feat: support affinity, nodeSelector and tolerations (taint)

### DIFF
--- a/charts/k8spacket/templates/daemonset.yaml
+++ b/charts/k8spacket/templates/daemonset.yaml
@@ -15,12 +15,24 @@ spec:
         {{- include "k8spacket.selectorLabels" . | nindent 8 }}
         name: {{ include "k8spacket.name" . }}
     spec:
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "k8spacket.serviceAccountName" . }}
       hostNetwork: true
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.priorityClassName }}

--- a/charts/k8spacket/values.yaml
+++ b/charts/k8spacket/values.yaml
@@ -4,7 +4,7 @@ affinity: {}
 
 image:
   repository: docker.io/k8spacket/k8spacket
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 serviceAccount:
   create: true

--- a/charts/k8spacket/values.yaml
+++ b/charts/k8spacket/values.yaml
@@ -1,5 +1,7 @@
 replicaCount: 1
 
+affinity: {}
+
 image:
   repository: k8spacket/k8spacket
   pullPolicy: Always
@@ -11,6 +13,8 @@ serviceAccount:
 
 clusterRole:
   create: true
+
+nodeSelector: {}
 
 podAnnotations: {}
 
@@ -36,6 +40,8 @@ resources:
   limits:
     memory: "1500Mi"
     cpu: "500m"
+
+tolerations: []
 
 k8sPacket:
   metrics:

--- a/charts/k8spacket/values.yaml
+++ b/charts/k8spacket/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 affinity: {}
 
 image:
-  repository: k8spacket/k8spacket
+  repository: docker.io/k8spacket/k8spacket
   pullPolicy: Always
 
 serviceAccount:


### PR DESCRIPTION
Support affinity, nodeSelector and tolerations (taint). Additionally, the container image name has been changed to the fully qualified name for cluster environments without supporting unqualified container registries. Furthermore, the default value of the pull strategy has been changed to IfNotPresent. Otherwise will be the image be pulled, even if it is present on a node.

