### PR TITLE
feat: Make volume host path configurable

### DIFF
--- a/charts/k8spacket/Chart.yaml
+++ b/charts/k8spacket/Chart.yaml
@@ -5,5 +5,5 @@ description: A Helm chart for k8spacket tool
 maintainers:
   - name: k8spacket
     email: k8spacket@gmail.com
-version: 2.0.1
+version: 2.0.2
 appVersion: 2.0.0

--- a/charts/k8spacket/templates/daemonset.yaml
+++ b/charts/k8spacket/templates/daemonset.yaml
@@ -104,4 +104,4 @@ spec:
           emptyDir: {}
         - name: tracing
           hostPath:
-            path: /sys/kernel/tracing
+            path: {{ .Values.k8sPacket.volumes.tracingPath }}

--- a/charts/k8spacket/values.yaml
+++ b/charts/k8spacket/values.yaml
@@ -88,3 +88,8 @@ k8sPacket:
     metrics:
       ## Enabled/disabled exposing TLS Prometheus metrics
       enabled: true
+  volumes:
+    ## path to kernel tracing folder on instance
+    ## default to /sys/kernel/tracing
+    ## on AmazonLinux this should be set to /sys/kernel/debug/tracing
+    tracingPath: /sys/kernel/tracing

--- a/charts/k8spacket/values.yaml
+++ b/charts/k8spacket/values.yaml
@@ -89,7 +89,8 @@ k8sPacket:
       ## Enabled/disabled exposing TLS Prometheus metrics
       enabled: true
   volumes:
-    ## path to kernel tracing folder on instance
-    ## default to /sys/kernel/tracing
-    ## on AmazonLinux this should be set to /sys/kernel/debug/tracing
+    ## path to kernel tracing folder on an instance
+    ## default to '/sys/kernel/tracing'
+    ## check by command: 'mount -t tracefs'
+    ## f.e. on 'Amazon Linux 2 Kernel 5.10' this should be set to '/sys/kernel/debug/tracing'
     tracingPath: /sys/kernel/tracing


### PR DESCRIPTION
This PR makes the volume section of the hostPath configurable.

This is needed, because on some operating systems the kernel tracing folders are different.

See this [issue](https://github.com/k8spacket/k8spacket/issues/51) for more context.