### PR TITLE
Optional Creation of ServiceMonitor

### DIFF
--- a/charts/k8spacket/Chart.yaml
+++ b/charts/k8spacket/Chart.yaml
@@ -5,5 +5,5 @@ description: A Helm chart for k8spacket tool
 maintainers:
   - name: k8spacket
     email: k8spacket@gmail.com
-version: 2.0.5
-appVersion: 2.0.5
+version: 2.0.6
+appVersion: 2.0.6

--- a/charts/k8spacket/Chart.yaml
+++ b/charts/k8spacket/Chart.yaml
@@ -6,4 +6,4 @@ maintainers:
   - name: k8spacket
     email: k8spacket@gmail.com
 version: 2.0.6
-appVersion: 2.0.6
+appVersion: 2.0.5

--- a/charts/k8spacket/templates/daemonset.yaml
+++ b/charts/k8spacket/templates/daemonset.yaml
@@ -69,6 +69,10 @@ spec:
               port: {{ .Values.k8sPacket.tcp.listener.port }}
             initialDelaySeconds: 15
             periodSeconds: 20
+          {{- if .Values.containerPorts }}
+          ports:
+            {{- toYaml .Values.containerPorts | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:

--- a/charts/k8spacket/templates/servicemonitor.yaml
+++ b/charts/k8spacket/templates/servicemonitor.yaml
@@ -24,4 +24,12 @@ spec:
     - targetPort: {{ default "metrics" .Values.k8sPacket.tcp.metrics.serviceMonitor.port | quote }}
       interval:  {{ default "30s" .Values.k8sPacket.tcp.metrics.serviceMonitor.interval | quote }}
       path: {{ default "/metrics" .Values.k8sPacket.tcp.metrics.serviceMonitor.path | quote }}
+      {{- with .Values.k8sPacket.tcp.metrics.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.k8sPacket.tcp.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
 {{- end }}

--- a/charts/k8spacket/templates/servicemonitor.yaml
+++ b/charts/k8spacket/templates/servicemonitor.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.k8sPacket.tcp.metrics.enabled .Values.k8sPacket.tcp.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "k8spacket.name" . }}
+  namespace: {{ default .Release.Namespace .Values.k8sPacket.tcp.metrics.serviceMonitor.namespace | quote }}
+  labels:
+    {{- include "k8spacket.labels" . | nindent 4 }}
+  {{- with .Values.k8sPacket.tcp.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.k8sPacket.tcp.metrics.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ default .Release.Namespace .Values.k8sPacket.tcp.metrics.serviceMonitor.namespace | quote }}
+  selector:
+    matchLabels:
+      {{- include "k8spacket.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - targetPort: {{ default "metrics" .Values.k8sPacket.tcp.metrics.serviceMonitor.port | quote }}
+      interval:  {{ default "30s" .Values.k8sPacket.tcp.metrics.serviceMonitor.interval | quote }}
+      path: {{ default "/metrics" .Values.k8sPacket.tcp.metrics.serviceMonitor.path | quote }}
+{{- end }}

--- a/charts/k8spacket/templates/servicemonitor.yaml
+++ b/charts/k8spacket/templates/servicemonitor.yaml
@@ -1,34 +1,34 @@
-{{- if and .Values.k8sPacket.tcp.metrics.enabled .Values.k8sPacket.tcp.metrics.serviceMonitor.enabled }}
+{{- if and (or .Values.k8sPacket.tcp.metrics.enabled .Values.k8sPacket.tls.metrics.enabled) .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "k8spacket.name" . }}
-  namespace: {{ default .Release.Namespace .Values.k8sPacket.tcp.metrics.serviceMonitor.namespace | quote }}
+  namespace: {{ default .Release.Namespace .Values.serviceMonitor.namespace | quote }}
   labels:
     {{- include "k8spacket.labels" . | nindent 4 }}
-  {{- with .Values.k8sPacket.tcp.metrics.serviceMonitor.labels }}
+  {{- with .Values.serviceMonitor.labels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.k8sPacket.tcp.metrics.serviceMonitor.annotations }}
+  {{- with .Values.serviceMonitor.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   namespaceSelector:
     matchNames:
-      - {{ default .Release.Namespace .Values.k8sPacket.tcp.metrics.serviceMonitor.namespace | quote }}
+      - {{ default .Release.Namespace .Values.serviceMonitor.namespace | quote }}
   selector:
     matchLabels:
       {{- include "k8spacket.selectorLabels" . | nindent 6 }}
   endpoints:
-    - targetPort: {{ default "metrics" .Values.k8sPacket.tcp.metrics.serviceMonitor.port | quote }}
-      interval:  {{ default "30s" .Values.k8sPacket.tcp.metrics.serviceMonitor.interval | quote }}
-      path: {{ default "/metrics" .Values.k8sPacket.tcp.metrics.serviceMonitor.path | quote }}
-      {{- with .Values.k8sPacket.tcp.metrics.serviceMonitor.relabelings }}
+    - targetPort: {{ default "metrics" .Values.serviceMonitor.port | quote }}
+      interval:  {{ default "30s" .Values.serviceMonitor.interval | quote }}
+      path: {{ default "/metrics" .Values.serviceMonitor.path | quote }}
+      {{- with .Values.serviceMonitor.relabelings }}
       relabelings:
         {{- toYaml . | nindent 6 }}
       {{- end }}
-      {{- with .Values.k8sPacket.tcp.metrics.serviceMonitor.metricRelabelings }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
       metricRelabelings:
         {{- toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/k8spacket/values.yaml
+++ b/charts/k8spacket/values.yaml
@@ -111,6 +111,12 @@ k8sPacket:
         ## Path that Prometheus will use to pull metrics from the container
         ##
         path: "/metrics"
+        ## RelabelConfigs to apply to samples before scraping
+        ##
+        relabelings: []
+        ## MetricRelabelConfigs to apply to samples before ingestion.
+        ##
+        metricRelabelings: []
   tls:
     certificate:
       cache:

--- a/charts/k8spacket/values.yaml
+++ b/charts/k8spacket/values.yaml
@@ -83,6 +83,34 @@ k8sPacket:
         command: "ip address | grep @ | sed -E 's/.* (\\w+)@.*/\\1/' | tr '\\n' ',' | sed 's/.$//'"
         ## How often refresh the list of network interfaces to listen
         refreshPeriod: "10s"
+    metrics:
+      ## Enabled/disabled exposing TCP Prometheus metrics
+      enabled: true
+      ## Hide source port when 'true' (set to string value 'dynamic' instead of decimal real source port) for Prometheus metrics cardinality reasons
+      hideSourcePort: true
+      ## Prometheus Operator ServiceMonitor configuration
+      serviceMonitor:
+        ## Note: metrics.serviceMonitor.enabled activation depends on containerPorts
+        ##
+        enabled: false
+        ## Specify the namespace for the ServiceMonitor
+        ##
+        namespace: ""
+        ## Define the scrape interval for Prometheus
+        ##
+        interval: ""
+        ## Extra labels for the ServiceMonitor
+        ##
+        labels: {}
+        ## Annotations for the ServiceMonitor
+        ##
+        annotations: {}
+        ## Define the port for Prometheus to scrape metrics
+        ##
+        port: "metrics"
+        ## Path that Prometheus will use to pull metrics from the container
+        ##
+        path: "/metrics"
   tls:
     certificate:
       cache:

--- a/charts/k8spacket/values.yaml
+++ b/charts/k8spacket/values.yaml
@@ -43,6 +43,11 @@ service:
   labels: {}
   annotations: {}
 
+containerPorts: []
+  # - name: metrics
+  #   containerPort: 6676
+  #   protocol: TCP
+
 resources:
   requests:
     memory: "100Mi"
@@ -78,11 +83,6 @@ k8sPacket:
         command: "ip address | grep @ | sed -E 's/.* (\\w+)@.*/\\1/' | tr '\\n' ',' | sed 's/.$//'"
         ## How often refresh the list of network interfaces to listen
         refreshPeriod: "10s"
-    metrics:
-      ## Enabled/disabled exposing TCP Prometheus metrics
-      enabled: true
-      ## Hide source port when 'true' (set to string value 'dynamic' instead of decimal real source port) for Prometheus metrics cardinality reasons
-      hideSourcePort: true
   tls:
     certificate:
       cache:

--- a/charts/k8spacket/values.yaml
+++ b/charts/k8spacket/values.yaml
@@ -58,6 +58,36 @@ resources:
 
 tolerations: []
 
+## Prometheus Operator ServiceMonitor configuration
+serviceMonitor:
+  ## Note: .serviceMonitor.enabled activation depends on containerPorts
+  ##
+  enabled: false
+  ## Specify the namespace for the ServiceMonitor
+  ##
+  namespace: ""
+  ## Define the scrape interval for Prometheus
+  ##
+  interval: ""
+  ## Extra labels for the ServiceMonitor
+  ##
+  labels: {}
+  ## Annotations for the ServiceMonitor
+  ##
+  annotations: {}
+  ## Define the port for Prometheus to scrape metrics
+  ##
+  port: "metrics"
+  ## Path that Prometheus will use to pull metrics from the container
+  ##
+  path: "/metrics"
+  ## RelabelConfigs to apply to samples before scraping
+  ##
+  relabelings: []
+  ## MetricRelabelConfigs to apply to samples before ingestion.
+  ##
+  metricRelabelings: []
+
 k8sPacket:
   ## Available plugin releases. Custom plugins can be provided
   api:
@@ -88,35 +118,6 @@ k8sPacket:
       enabled: true
       ## Hide source port when 'true' (set to string value 'dynamic' instead of decimal real source port) for Prometheus metrics cardinality reasons
       hideSourcePort: true
-      ## Prometheus Operator ServiceMonitor configuration
-      serviceMonitor:
-        ## Note: metrics.serviceMonitor.enabled activation depends on containerPorts
-        ##
-        enabled: false
-        ## Specify the namespace for the ServiceMonitor
-        ##
-        namespace: ""
-        ## Define the scrape interval for Prometheus
-        ##
-        interval: ""
-        ## Extra labels for the ServiceMonitor
-        ##
-        labels: {}
-        ## Annotations for the ServiceMonitor
-        ##
-        annotations: {}
-        ## Define the port for Prometheus to scrape metrics
-        ##
-        port: "metrics"
-        ## Path that Prometheus will use to pull metrics from the container
-        ##
-        path: "/metrics"
-        ## RelabelConfigs to apply to samples before scraping
-        ##
-        relabelings: []
-        ## MetricRelabelConfigs to apply to samples before ingestion.
-        ##
-        metricRelabelings: []
   tls:
     certificate:
       cache:


### PR DESCRIPTION
This optional configuration allows users to enable the creation of a ServiceMonitor for scraping individual metrics from DaemonSets on a per-pod basis. By enabling this feature, you can collect and store metrics from all nodes, providing comprehensive monitoring across your entire cluster.
